### PR TITLE
extension-home-page: the secret life of badges

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,3 @@
+# These owners will be the default owners for everything in the repo, unless a later match takes precedence
+
 * @msorens @lkwdwrd

--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -19,7 +19,7 @@ jobs:
       with:
         node-version: '18'
 
-    - run: npm install
+    - run: npm ci
     - run: npm run test
     - run: git diff --exit-code README.md
 
@@ -33,7 +33,7 @@ jobs:
       with:
         node-version: '18'
 
-    - run: npm install
+    - run: npm ci
     - run: npm run lint
 
   license:
@@ -46,7 +46,7 @@ jobs:
       with:
         node-version: '18'
 
-    - run: npm install
+    - run: npm ci
     - run: npm run check-licenses
 
   stale:
@@ -58,7 +58,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '18'
-      - run: npm install
+      - run: npm ci
 
       - name: Regenerate JSON file from YAML source
         run: npx ts-node src/scripts/yaml2json.ts

--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -20,7 +20,9 @@ jobs:
         node-version: '18'
 
     - run: npm install
-    - run: npm run test:ci
+    - run: npm install -g ts-node
+    - run: npm run test
+    - run: git diff --exit-code README.md
 
   lint:
     runs-on: ubuntu-latest
@@ -60,11 +62,8 @@ jobs:
       - run: npm install
       - run: npm install -g ts-node
 
-      - name: Move current file
-        run: mv snippets/styra-common.json snippets/styra-common.json.LAST
-
       - name: Regenerate JSON file from YAML source
         run: ts-node src/scripts/yaml2json.ts
 
-      - name: Compare files
-        run: diff snippets/styra-common.json snippets/styra-common.json.LAST
+      - name: Compare snippet file
+        run: git diff --exit-code snippets/styra-common.json

--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -20,7 +20,6 @@ jobs:
         node-version: '18'
 
     - run: npm install
-    - run: npm install -g ts-node
     - run: npm run test
     - run: git diff --exit-code README.md
 
@@ -60,10 +59,9 @@ jobs:
         with:
           node-version: '18'
       - run: npm install
-      - run: npm install -g ts-node
 
       - name: Regenerate JSON file from YAML source
-        run: ts-node src/scripts/yaml2json.ts
+        run: npx ts-node src/scripts/yaml2json.ts
 
       - name: Compare snippet file
         run: git diff --exit-code snippets/styra-common.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added CONTRIBUTING.md to repository in preparation for going public.
 - Added issue templates for community members to more easily participate.
 - Removed restriction on commit formatting to make it less arduous for community members.
+- Additional info badges to top of extension's home page in VS Code (Slack, CI status, PR count)
 
 ## [1.1.0] - 2023-04-06
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,15 @@
 <!-- markdownlint-disable MD041 -->
-[![Apache License](https://img.shields.io/badge/license-Apache%202.0-orange.svg?style=flat-square)](https://www.apache.org/licenses/LICENSE-2.0)
-![Visual Studio Marketplace Version](https://img.shields.io/visual-studio-marketplace/v/Styra.vscode-styra?style=flat-square)
+[![slack](https://img.shields.io/badge/slack-styra-24b6e0.svg?logo=slack)](https://styracommunity.slack.com/)
+[![Apache License](https://img.shields.io/badge/license-Apache%202.0-orange.svg)](https://www.apache.org/licenses/LICENSE-2.0)
+![Visual Studio Marketplace Version](https://img.shields.io/visual-studio-marketplace/v/Styra.vscode-styra?color=24b6e0)
 ![Coverage](https://img.shields.io/badge/Coverage-70%25-brightgreen)
-<!-- https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge -->
-<!-- wait until the repo is public for this one:
-![CI status](https://github.com/StyraInc/vscode-styra/actions/workflows/main.yaml/badge.svg)
+[![CI status](https://github.com/StyraInc/vscode-styra/actions/workflows/main.yaml/badge.svg)](https://github.com/StyraInc/vscode-styra/actions/workflows/main.yaml)
+[![closed PRs](https://img.shields.io/github/issues-pr-closed-raw/StyraInc/vscode-styra)](https://github.com/StyraInc/vscode-styra/pulls?q=is%3Apr+is%3Aclosed)
+<!--
+  Notes for above:
+  24b6e0 is Styra blue!
+  Slack: https://github.com/brigadecore/brigade-foundations/pull/17/files
+  CI status: https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge
 -->
 
 # Styra DAS for Visual Studio Code

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![slack](https://img.shields.io/badge/slack-styra-24b6e0.svg?logo=slack)](https://styracommunity.slack.com/)
 [![Apache License](https://img.shields.io/badge/license-Apache%202.0-orange.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 [![Visual Studio Marketplace Version](https://img.shields.io/visual-studio-marketplace/v/Styra.vscode-styra?color=24b6e0)](#)
-[![Coverage](https://img.shields.io/badge/Coverage-65%25-brightgreen)](#)
+[![Coverage](https://img.shields.io/badge/Coverage-70%25-brightgreen)](#)
 [![CI status](https://github.com/StyraInc/vscode-styra/actions/workflows/main.yaml/badge.svg)](https://github.com/StyraInc/vscode-styra/actions/workflows/main.yaml)
 [![closed PRs](https://img.shields.io/github/issues-pr-closed-raw/StyraInc/vscode-styra)](https://github.com/StyraInc/vscode-styra/pulls?q=is%3Apr+is%3Aclosed)
 <!--

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <!-- markdownlint-disable MD041 -->
 [![slack](https://img.shields.io/badge/slack-styra-24b6e0.svg?logo=slack)](https://styracommunity.slack.com/)
 [![Apache License](https://img.shields.io/badge/license-Apache%202.0-orange.svg)](https://www.apache.org/licenses/LICENSE-2.0)
-![Visual Studio Marketplace Version](https://img.shields.io/visual-studio-marketplace/v/Styra.vscode-styra?color=24b6e0)
-![Coverage](https://img.shields.io/badge/Coverage-70%25-brightgreen)
+[![Visual Studio Marketplace Version](https://img.shields.io/visual-studio-marketplace/v/Styra.vscode-styra?color=24b6e0)](#)
+[![Coverage](https://img.shields.io/badge/Coverage-70%25-brightgreen)](#)
 [![CI status](https://github.com/StyraInc/vscode-styra/actions/workflows/main.yaml/badge.svg)](https://github.com/StyraInc/vscode-styra/actions/workflows/main.yaml)
 [![closed PRs](https://img.shields.io/github/issues-pr-closed-raw/StyraInc/vscode-styra)](https://github.com/StyraInc/vscode-styra/pulls?q=is%3Apr+is%3Aclosed)
 <!--

--- a/README.md
+++ b/README.md
@@ -61,6 +61,13 @@ All of these start with "rego" as the trigger, so just type that into a rego fil
 | `Styra > Diagnostic Output` | false | Reveal API calls and other diagnostic details in the output pane. |
 | `Styra > Output Format` | table | Selects the output format for commands that return data. |
 
+## Feedback
+
+We are always interested in your feedback, issue reports, and feature requests!
+Please connect with us on the `#vscode` channel on [Slack](https://styracommunity.slack.com)
+or on [Discussions](https://github.com/StyraInc/vscode-styra/discussions)
+or [Issues](https://github.com/StyraInc/vscode-styra/issues) in the GitHub repository.
+
 ## Known Issues
 
 None

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ All of these start with "rego" as the trigger, so just type that into a rego fil
 | Setting | Default | Description |
 | --- | --- | --- |
 | `Styra > Check Update Interval` | 1 | How often to check for updates to the Styra CLI (in days). |
+| `Styra > Diagnostic Limit` | 120 | Length limit of diagnostic output (use -1 for no limit). |
 | `Styra > Diagnostic Output` | false | Reveal API calls and other diagnostic details in the output pane. |
 | `Styra > Output Format` | table | Selects the output format for commands that return data. |
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![slack](https://img.shields.io/badge/slack-styra-24b6e0.svg?logo=slack)](https://styracommunity.slack.com/)
 [![Apache License](https://img.shields.io/badge/license-Apache%202.0-orange.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 [![Visual Studio Marketplace Version](https://img.shields.io/visual-studio-marketplace/v/Styra.vscode-styra?color=24b6e0)](#)
-[![Coverage](https://img.shields.io/badge/Coverage-70%25-brightgreen)](#)
+[![Coverage](https://img.shields.io/badge/Coverage-65%25-brightgreen)](#)
 [![CI status](https://github.com/StyraInc/vscode-styra/actions/workflows/main.yaml/badge.svg)](https://github.com/StyraInc/vscode-styra/actions/workflows/main.yaml)
 [![closed PRs](https://img.shields.io/github/issues-pr-closed-raw/StyraInc/vscode-styra)](https://github.com/StyraInc/vscode-styra/pulls?q=is%3Apr+is%3Aclosed)
 <!--

--- a/jest.config.js
+++ b/jest.config.js
@@ -14,12 +14,17 @@ module.exports = {
   coverageReporters: [
     'text',        // displays coverage per file on console
     'html',        // generates HTML report in coverage/index.html
-    'json-summary' // outputs results as JSON to coverage/coverage-summary.json'
+    'json-summary' // generates coverage/coverage-summary.json used by update-coverage.ts script
   ],
   preset: 'ts-jest',
   testEnvironment: 'node',
   resetMocks: true,
   // roots: ['src'],
   setupFiles: ['./src/test-jest/vscode-mock.ts'],
-  testPathIgnorePatterns: [...defaults.testPathIgnorePatterns, 'src/test/suite', 'out/test/suite', '.js'],
+  testPathIgnorePatterns: [
+    ...defaults.testPathIgnorePatterns,
+    'src/test/suite',
+    'out/test/suite',
+    '.js'
+  ],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "jest": "^29.3.1",
         "js-yaml": "^4.1.0",
         "ts-jest": "^29.0.5",
+        "ts-node": "^10.9.1",
         "typescript": "^4.3.2",
         "vscode-test": "^1.5.2"
       },
@@ -1871,6 +1872,28 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "node_modules/@esbuild/android-arm": {
       "version": "0.17.6",
       "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.6.tgz",
@@ -2804,6 +2827,30 @@
         "node": ">= 6"
       }
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
+      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
+      "dev": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.1.20",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.20.tgz",
@@ -3170,6 +3217,15 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
@@ -3267,6 +3323,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -3794,6 +3856,12 @@
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "dev": true
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -3862,6 +3930,15 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/diff-sequences": {
@@ -6865,6 +6942,61 @@
         "node": ">=12"
       }
     },
+    "node_modules/ts-node": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+      "dev": true,
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-node/node_modules/acorn": {
+      "version": "8.8.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
+      "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -7045,6 +7177,12 @@
       "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
       "dev": true
     },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true
+    },
     "node_modules/v8-to-istanbul": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.0.1.tgz",
@@ -7210,6 +7348,15 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
@@ -8518,6 +8665,27 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "dependencies": {
+        "@jridgewell/trace-mapping": {
+          "version": "0.3.9",
+          "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+          "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+          "dev": true,
+          "requires": {
+            "@jridgewell/resolve-uri": "^3.0.3",
+            "@jridgewell/sourcemap-codec": "^1.4.10"
+          }
+        }
+      }
+    },
     "@esbuild/android-arm": {
       "version": "0.17.6",
       "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.6.tgz",
@@ -9136,6 +9304,30 @@
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
       "dev": true
     },
+    "@tsconfig/node10": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
+      "dev": true
+    },
+    "@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true
+    },
+    "@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true
+    },
+    "@tsconfig/node16": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
+      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
+      "dev": true
+    },
     "@types/babel__core": {
       "version": "7.1.20",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.20.tgz",
@@ -9420,6 +9612,12 @@
       "dev": true,
       "requires": {}
     },
+    "acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "dev": true
+    },
     "agent-base": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
@@ -9488,6 +9686,12 @@
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
       }
+    },
+    "arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
     },
     "argparse": {
       "version": "2.0.1",
@@ -9880,6 +10084,12 @@
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "dev": true
     },
+    "create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
+    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -9928,6 +10138,12 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+      "dev": true
+    },
+    "diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
       "dev": true
     },
     "diff-sequences": {
@@ -12197,6 +12413,35 @@
         }
       }
     },
+    "ts-node": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+      "dev": true,
+      "requires": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "8.8.2",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
+          "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
+          "dev": true
+        }
+      }
+    },
     "tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -12319,6 +12564,12 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
       "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
+      "dev": true
+    },
+    "v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true
     },
     "v8-to-istanbul": {
@@ -12453,6 +12704,12 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true
     },
     "yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
           "description": "Length limit of diagnostic output (use -1 for no limit)",
           "default": 120
         },
-         "styra.diagnosticOutput": {
+        "styra.diagnosticOutput": {
           "type": "boolean",
           "description": "Reveal API calls and other diagnostics in output pane",
           "default": false
@@ -129,12 +129,12 @@
     "lint:fix": "eslint --fix src --ext ts",
     "pretest-vscode": "npm run compile && npm run lint",
     "test-vscode": "node ./out/test/runTest.js",
-    "test": "jest; ts-node src/scripts/update-coverage.ts",
+    "test": "jest; npx ts-node src/scripts/update-coverage.ts",
     "test:ci": "jest --collectCoverage false",
     "test:verbose": "jest --verbose",
     "test:watch": "jest --watch",
     "watch": "tsc -watch -p ./",
-    "snippets:build:common": "ts-node src/scripts/yaml2json.ts",
+    "snippets:build:common": "npx ts-node src/scripts/yaml2json.ts",
     "view-coverage": "open coverage/index.html"
   },
   "devDependencies": {
@@ -161,6 +161,7 @@
     "jest": "^29.3.1",
     "js-yaml": "^4.1.0",
     "ts-jest": "^29.0.5",
+    "ts-node": "^10.9.1",
     "typescript": "^4.3.2",
     "vscode-test": "^1.5.2"
   },

--- a/snippets/styra-common.json
+++ b/snippets/styra-common.json
@@ -37,6 +37,7 @@
   },
   "Conjunction of rules": {
     "prefix": "rego_ex_CONDITION_AND",
+    "description": "Determine whether all conditions are satisfied",
     "scope": "rego",
     "body": [
       "###########################################################################################",

--- a/snippets/styra-common.json
+++ b/snippets/styra-common.json
@@ -37,7 +37,6 @@
   },
   "Conjunction of rules": {
     "prefix": "rego_ex_CONDITION_AND",
-    "description": "Determine whether all conditions are satisfied",
     "scope": "rego",
     "body": [
       "###########################################################################################",

--- a/snippets/styra-common.json
+++ b/snippets/styra-common.json
@@ -31,6 +31,7 @@
       "#    Rego Language https://www.openpolicyagent.org/docs/latest/policy-reference/",
       "#    Rego Playground https://play.openpolicyagent.org/",
       "#    Styra DAS https://docs.styra.com/das",
+      "#    Styra on Slack https://styracommunity.slack.com",
       ""
     ]
   },

--- a/snippets/styra-common.yaml
+++ b/snippets/styra-common.yaml
@@ -30,6 +30,7 @@ Styra Link intro:
     #    Rego Language https://www.openpolicyagent.org/docs/latest/policy-reference/
     #    Rego Playground https://play.openpolicyagent.org/
     #    Styra DAS https://docs.styra.com/das
+    #    Styra on Slack https://styracommunity.slack.com
 
 Conjunction of rules:
   prefix: rego_ex_CONDITION_AND

--- a/src/README.md
+++ b/src/README.md
@@ -21,15 +21,18 @@ What you should see:
 2. In the Terminal window you should see a new task launched: `npm esbuild-watch` with some nominal output.
 3. A new VSCode window opens ("Extension Development Host").
 
-The Styra extension how acts almost exactly as if you had installed it through normal means, with a couple exceptions:
+The Styra extension in the new window acts almost exactly as if you had installed it through normal means, with a couple exceptions:
 (a) You will not find it listed in the "Extensions" pane (unless you previously installed it like a normal extension!).
 (b) Since VSCode is built with Electron, you can open the same DevTools panel in VSCode that you are familiar with from Chrome!
 Use `Help > Toggle Developer Tools` or the shortcut `⌥ + ⌘ + I`.
 
-Get friendly with the `Console` tab of the Developer Tools. Just like in Chrome, any `console.log` statements in your code will send there—NOT to the standard VSCode "Debug Console"! Also any exceptions that your code throws will appear there.
+Get friendly with the `Console` tab of the Developer Tools.
+Just like in Chrome, any `console.log` statements in your code will emit there—NOT to the standard VSCode "Debug Console"!
+Also any exceptions that your code throws will appear there.
 
 While you will find local storage and session storage under the Developer Tools "Application" tab just like Chrome,
-that is NOT where VSCode local storage persists. Rather it is stored via the Memento API (see <https://stackoverflow.com/a/51822055>).
+that is NOT where VSCode local storage persists.
+Rather it is stored via the Memento API (see <https://stackoverflow.com/a/51822055>).
 You can use the VSCode "Memento Explorer" extension to view and modify that local storage. See extension.ts for details.
 
 ## Unit Tests

--- a/src/scripts/README.md
+++ b/src/scripts/README.md
@@ -1,5 +1,8 @@
 # Standalone Utilities
 
+Commands in this folder are standalone utilities
+for various bookkeeping activities associated with the extension.
+
 ## Prerequisites
 
 ### ts-node


### PR DESCRIPTION
### What code changed, and why?

Adding feedback channels and adding new badges.

<img width="907" alt="image" src="https://user-images.githubusercontent.com/6817500/232193814-7d4c17a5-62ec-4154-aea6-f212de00a627.png">

### About Badges

It is difficult to say when badges first started being used in top-level README.md files, but they have definitely hit their stride when it comes to providing quick access to key facts about a VS Code extension. There are a lot of extensions that do not use them, but those that do have a certain... panache to them... so naturally it makes sense to use them for our Styra extension. 😁 

The starting point for _all-things-badge_ is https://shields.io/, the premier source of badges [deemed acceptable by Microsoft in VS Code extensions](https://code.visualstudio.com/api/references/extension-manifest#approved-badges). (Almost all of the other badge providers listed there are for specific products, whereas shields.io is not product-specific.)
And, indeed, 5 of the 6 badges I am using come from shields.io.

Badge | Static or Dynamic | Parameterized? | Link Target
-------|-------------------|----------------|------------
Slack | static | color set in the "file name" | https://styracommunity.slack.com/
License | static | color set in the "file name" | https://www.apache.org/licenses/LICENSE-2.0
Version | dynamic from marketplace data | `color` parameter in URL | none
Code coverage | static/from README.md file--must be updated by running `npm test` | color based on scripted thresholds | none
CI status | dynamic from github data | color (presumably) set by status | https://github.com/StyraInc/vscode-styra/actions/workflows/main.yaml
Closed PRs | dynamic from github data | none | https://github.com/StyraInc/vscode-styra/pulls?q=is%3Apr+is%3Aclosed

_A note on code coverage:_ unlike things like CodeCov that have dynamically-sourced badges, I am not using anything special for code coverage, just the coverage generation built into jest. So whenever one runs tests (`npm test`) there is a post-test script that updates the code coverage value and color in the README.md with the results from the test run. So the only thing the developer has to do is commit that change in their PR. Lest he or she forget, I have also added a "staleness" check for that, attached to the github `test` action. At the high level, the `test` check would show failure; and the details would show this (I have highlighted where the code coverage hypothetically changed from 65% to 70%):

<img width="1136" alt="image" src="https://user-images.githubusercontent.com/6817500/232333946-36e1f0b2-46a0-48b6-8f45-cb1860ad23bb.png">


### Definition of done

- [x] Adding Styra community slack to readme and to rego_help snippet.
- [x] Adding GitHub issues and discussions links to readme.
- [x] Adding additional badges to top of readme (slack, CI status, PR count).
- [x] Add staleness check for committing the updated code coverage.
- [x] Bonus: Added documentation line in readme for recently added VS Code setting.
- [x] Bonus: A few minor doc/comment tweaks.

### How to test

You can install either from source code or from GitHub.

#### Install from source

1. Switch to current branch.
2. Run `npm install`.
3. Open project in VSCode.
4. In the debugger be sure you have "Run Extension" mode selected.
5. Invoke "run" (<kbd>F5</kbd>).

#### Install from GitHub

1. Go to the latest release on the [release page](https://github.com/StyraInc/vscode-styra/releases).
2. Download the additional version piggybacked into that release, labelled `vscode-styra-n.n.n-next.N.vsix`.
3. Install via the standard command: `code --install-extension vscode-styra-n.n.n-next.N.vsix`

#### Exercise the Code

Review extension home page

### Related Resources

STY-16136
