### PR TITLE
vscode-settings: tidied up handling

### DIFF
--- a/src/commands/executor.ts
+++ b/src/commands/executor.ts
@@ -30,7 +30,7 @@ export class Executor {
       }
     } catch (err) {
       // using `err` arg instead of `{message}` as it is easier to grab the stack trace on occasion
-      teeError((err as Error).message as string);
+      teeError((err as Error).message);
       info(`====> ${command.title} failed`);
     }
     this.StorageManager.setValue<string>(Workspace.CmdName, '');

--- a/src/commands/link-search.ts
+++ b/src/commands/link-search.ts
@@ -1,10 +1,10 @@
 import {CommandRunner} from '../lib/command-runner';
 import {generatePickList, shouldResume, StepType, validateNoop} from './utility';
+import {getSetting, Setting} from '../lib/ide-settings';
 import {ICommand, ReturnValue} from '../lib/types';
-import {IDE, QuickPickItem} from '../lib/vscode-api';
 import {info, infoDiagram} from '../lib/output-pane';
 import {MultiStepInput} from '../external/multi-step-input';
-import {Setting} from '../lib/ide-settings';
+import {QuickPickItem} from '../lib/vscode-api';
 
 interface State {
   _searchByTitle: QuickPickItem;
@@ -41,7 +41,7 @@ export class LinkSearch implements ICommand {
     } else {
       styraArgs.push('--rule', state.searchTerm);
     }
-    const outputFormat = IDE.getConfigValue<string>('styra', Setting.Format);
+    const outputFormat = getSetting<string>(Setting.Format);
     if (outputFormat) {
       styraArgs.push('--output', outputFormat.toLowerCase());
     }

--- a/src/commands/link-test.ts
+++ b/src/commands/link-test.ts
@@ -1,8 +1,7 @@
 import {CommandRunner} from '../lib/command-runner';
+import {getSetting, Setting} from '../lib/ide-settings';
 import {ICommand, ReturnValue} from '../lib/types';
-import {IDE} from '../lib/vscode-api';
 import {info} from '../lib/output-pane';
-import {Setting} from '../lib/ide-settings';
 
 export class LinkTest implements ICommand {
 
@@ -11,7 +10,7 @@ export class LinkTest implements ICommand {
   async run(): Promise<ReturnValue> {
 
     const styraArgs = ['link', 'test'];
-    const outputFormat = IDE.getConfigValue<string>('styra', Setting.Format);
+    const outputFormat = getSetting<string>(Setting.Format);
     if (outputFormat) {
       styraArgs.push('--output', outputFormat.toLowerCase());
     }

--- a/src/commands/link-validate-compliance.ts
+++ b/src/commands/link-validate-compliance.ts
@@ -1,8 +1,7 @@
 import {CommandRunner} from '../lib/command-runner';
+import {getSetting, Setting} from '../lib/ide-settings';
 import {ICommand, ReturnValue} from '../lib/types';
-import {IDE} from '../lib/vscode-api';
 import {info, teeWarning} from '../lib/output-pane';
-import {Setting} from '../lib/ide-settings';
 import {StyraConfig} from '../lib/styra-config';
 
 export class LinkValidateCompliance implements ICommand {
@@ -17,7 +16,7 @@ export class LinkValidateCompliance implements ICommand {
     }
 
     const styraArgs = ['link', 'validate', 'compliance'];
-    const outputFormat = IDE.getConfigValue<string>('styra', Setting.Format);
+    const outputFormat = getSetting<string>(Setting.Format);
     if (outputFormat) {
       styraArgs.push('--output', outputFormat.toLowerCase());
     }

--- a/src/commands/link-validate-decisions.ts
+++ b/src/commands/link-validate-decisions.ts
@@ -1,8 +1,7 @@
 import {CommandRunner} from '../lib/command-runner';
+import {getSetting, Setting} from '../lib/ide-settings';
 import {ICommand, ReturnValue} from '../lib/types';
-import {IDE} from '../lib/vscode-api';
 import {info} from '../lib/output-pane';
-import {Setting} from '../lib/ide-settings';
 
 export class LinkValidateDecisions implements ICommand {
 
@@ -11,7 +10,7 @@ export class LinkValidateDecisions implements ICommand {
   async run(): Promise<ReturnValue> {
 
     const styraArgs = ['link', 'validate', 'decisions'];
-    const outputFormat = IDE.getConfigValue<string>('styra', Setting.Format);
+    const outputFormat = getSetting<string>(Setting.Format);
     if (outputFormat) {
       styraArgs.push('--output', outputFormat.toLowerCase());
     }

--- a/src/lib/command-runner.ts
+++ b/src/lib/command-runner.ts
@@ -2,10 +2,10 @@ import {ChildProcessWithoutNullStreams, spawn, SpawnOptionsWithoutStdio} from 'c
 import {sync as commandExistsSync} from 'command-exists';
 import shellEscape = require('shell-escape');
 
+import {getSetting, Setting} from './ide-settings';
 import {IDE} from './vscode-api';
 import {info, infoDebug, teeError} from './output-pane';
 import {LocalStorageService, Workspace} from './local-storage-service';
-import {Setting} from './ide-settings';
 import {STYRA_CLI_CMD, StyraInstall} from './styra-install';
 
 type CommandRunnerOptions = {
@@ -66,7 +66,7 @@ export class CommandRunner {
   // so in that case the diagnostic lines will NOT be prefixed with `[DEBUG]`.
   // Bug? Feature? You decide :-).
   private async runWithOptionalDebug(args: string[], options?: CommandRunnerOptions): Promise<string> {
-    if (IDE.getConfigValue<boolean>('styra', Setting.Diagnostic) ?? false) {
+    if (getSetting<boolean>(Setting.Diagnostic)) {
       args.push('--debug');
       let result = (await this.runShellCmd(STYRA_CLI_CMD, args, options)).split('\n');
       result.filter(this.isDebugLine).forEach(infoDebug);

--- a/src/lib/ide-settings.ts
+++ b/src/lib/ide-settings.ts
@@ -1,3 +1,5 @@
+import {IDE} from './vscode-api';
+
 // These must match package.json!
 // Also make sure that changes are reflected in mockVSCodeSettings.
 export enum Setting {
@@ -5,4 +7,21 @@ export enum Setting {
   DiagnosticLimit = 'diagnosticLimit',
   Format = 'outputFormat',
   UpdateInterval = 'checkUpdateInterval'
+}
+
+export const settingDefaults =
+  {
+    [Setting.Diagnostic]: false,
+    [Setting.DiagnosticLimit]: 120,
+    [Setting.Format]: 'table',
+    [Setting.UpdateInterval]: 1
+  };
+
+// function to retrieve generic setting from IDE.getConfigValue with first arg 'styra';
+// second arg must be one of the enum Setting values.
+// If the value of IDE.getConfigValue is undefined, return instead a default from the defaults constant
+export function getSetting<T>(setting: Setting): T {
+  const configValue = IDE.getConfigValue<T>('styra', setting);
+  const defaultValue = settingDefaults[setting];
+  return (configValue ?? defaultValue) as T;
 }

--- a/src/lib/ide-settings.ts
+++ b/src/lib/ide-settings.ts
@@ -9,19 +9,8 @@ export enum Setting {
   UpdateInterval = 'checkUpdateInterval'
 }
 
-export const settingDefaults =
-  {
-    [Setting.Diagnostic]: false,
-    [Setting.DiagnosticLimit]: 120,
-    [Setting.Format]: 'table',
-    [Setting.UpdateInterval]: 1
-  };
-
 // function to retrieve generic setting from IDE.getConfigValue with first arg 'styra';
 // second arg must be one of the enum Setting values.
-// If the value of IDE.getConfigValue is undefined, return instead a default from the defaults constant
 export function getSetting<T>(setting: Setting): T {
-  const configValue = IDE.getConfigValue<T>('styra', setting);
-  const defaultValue = settingDefaults[setting];
-  return (configValue ?? defaultValue) as T;
+  return IDE.getConfigValue<T>('styra', setting) as T;
 }

--- a/src/lib/output-pane.ts
+++ b/src/lib/output-pane.ts
@@ -1,5 +1,5 @@
+import {getSetting, Setting} from './ide-settings';
 import {IDE} from './vscode-api';
-import {Setting} from './ide-settings';
 
 export const outputChannel = IDE.createOutputChannel('Styra');
 export const footnoteMsg = '(*) See output pane (*)';
@@ -38,8 +38,8 @@ export function infoFromUserAction(msg: string): void {
 
 // Use this to report debug-level messages
 export function infoDebug(msg: string): void {
-  if (IDE.getConfigValue<boolean>('styra', Setting.Diagnostic)) {
-    const limit = IDE.getConfigValue<number>('styra', Setting.DiagnosticLimit) ?? -1;
+  if (getSetting<boolean>(Setting.Diagnostic)) {
+    const limit = getSetting<number>(Setting.DiagnosticLimit);
     if (limit !== -1 && msg.length > limit) {
       msg = msg.substring(0, limit) + '...';
     }

--- a/src/lib/styra-config.ts
+++ b/src/lib/styra-config.ts
@@ -85,8 +85,8 @@ export class StyraConfig {
       );
       IDE.showInformationMessage('Styra CLI configured.');
       info('Configuration complete');
-    } catch ({message}) { // invalid URL or TOKEN will typically trigger this
-      teeError(message as string);
+    } catch (err) { // invalid URL or TOKEN will typically trigger this
+      teeError((err as Error).message);
       info('Configuration failed');
       return false;
     }

--- a/src/lib/styra-install.ts
+++ b/src/lib/styra-install.ts
@@ -9,11 +9,11 @@ import {compare} from 'semver';
 
 import {CommandRunner} from './command-runner';
 import {DAS} from './das-query';
+import {getSetting, Setting} from './ide-settings';
 import {IDE} from './vscode-api';
 import {info, infoDebug, infoFromUserAction, infoInput, teeError, teeInfo} from './output-pane';
 import {LocalStorageService, Workspace} from './local-storage-service';
 import {MultiStepInput} from '../external/multi-step-input';
-import {Setting} from './ide-settings';
 import {shouldResume, validateNoop} from '../commands/utility';
 import {VersionType} from './types';
 
@@ -78,7 +78,7 @@ export class StyraInstall {
   static async checkForUpdates(): Promise<void> {
     const localStorage = LocalStorageService.instance;
     const last = localStorage.getValue<string>(Workspace.UpdateCheckDate);
-    const interval = IDE.getConfigValue<number>('styra', Setting.UpdateInterval) ?? 1;
+    const interval = getSetting<number>(Setting.UpdateInterval);
     const currentDate = new Date(Date.now());
 
     // run check periodically based on user preference in VSCode settings

--- a/src/lib/styra-install.ts
+++ b/src/lib/styra-install.ts
@@ -91,8 +91,8 @@ export class StyraInstall {
           await StyraInstall.promptForInstall(
             `has an update available (installed=${installedVersion}, available=${available.cliVersion})`, 'update');
         }
-      } catch ({message}) {
-        teeError(message as string);
+      } catch (err) {
+        teeError((err as Error).message);
       }
     }
   }

--- a/src/test-jest/utility.ts
+++ b/src/test-jest/utility.ts
@@ -1,5 +1,5 @@
 import {outputChannel} from '../lib/output-pane';
-import {Setting} from '../lib/ide-settings';
+import {Setting, settingDefaults} from '../lib/ide-settings';
 
 export class OutputPaneSpy {
   private spyAppendLine = jest.spyOn(outputChannel, 'appendLine');
@@ -22,26 +22,18 @@ type SettingMockOptions = {
   checkUpdateInterval?: number;
 }
 
-// defaults should match contributes.configuration.properties from package.json
-const defaultSettingMockOptions: SettingMockOptions = {
-  outputFormat: 'table',
-  diagnosticOutput: false,
-  diagnosticLimit: 120,
-  checkUpdateInterval: 0
-};
-
-export function mockVSCodeSettings(options: SettingMockOptions = defaultSettingMockOptions): jest.Mock {
+export function mockVSCodeSettings(options: SettingMockOptions = {}): jest.Mock {
   return jest.fn().mockImplementation(
-    (path, key) => {
+    (_path, key: string) => {
       switch (key) {
         case Setting.Format:
-          return options.outputFormat;
+          return options.outputFormat ?? settingDefaults[key];
         case Setting.Diagnostic:
-          return options.diagnosticOutput;
+          return options.diagnosticOutput ?? settingDefaults[key];
         case Setting.DiagnosticLimit:
-          return options.diagnosticLimit;
+          return options.diagnosticLimit ?? settingDefaults[key];
         case Setting.UpdateInterval:
-          return options.checkUpdateInterval;
+          return options.checkUpdateInterval ?? settingDefaults[key];
       }
     });
 }

--- a/src/test-jest/utility.ts
+++ b/src/test-jest/utility.ts
@@ -1,5 +1,5 @@
 import {outputChannel} from '../lib/output-pane';
-import {Setting, settingDefaults} from '../lib/ide-settings';
+import {Setting} from '../lib/ide-settings';
 
 export class OutputPaneSpy {
   private spyAppendLine = jest.spyOn(outputChannel, 'appendLine');
@@ -22,18 +22,26 @@ type SettingMockOptions = {
   checkUpdateInterval?: number;
 }
 
-export function mockVSCodeSettings(options: SettingMockOptions = {}): jest.Mock {
+// defaults should match contributes.configuration.properties from package.json
+const defaultSettingMockOptions: SettingMockOptions = {
+  outputFormat: 'table',
+  diagnosticOutput: false,
+  diagnosticLimit: 120,
+  checkUpdateInterval: 1
+};
+
+export function mockVSCodeSettings(options: SettingMockOptions = defaultSettingMockOptions): jest.Mock {
   return jest.fn().mockImplementation(
-    (_path, key: string) => {
+    (path, key) => {
       switch (key) {
         case Setting.Format:
-          return options.outputFormat ?? settingDefaults[key];
+          return options.outputFormat;
         case Setting.Diagnostic:
-          return options.diagnosticOutput ?? settingDefaults[key];
+          return options.diagnosticOutput;
         case Setting.DiagnosticLimit:
-          return options.diagnosticLimit ?? settingDefaults[key];
+          return options.diagnosticLimit;
         case Setting.UpdateInterval:
-          return options.checkUpdateInterval ?? settingDefaults[key];
+          return options.checkUpdateInterval;
       }
     });
 }


### PR DESCRIPTION
### What code changed, and why?

Tidied up handling of VS Code settings.

### Definition of done

- [x] Added helper so calls can be just one argument instead of two (the second argument was always the same).
- [x] Removed superfluous default check-and-add when fetching values; VS Code infrastructure guarantees defaults are always in place.
- [x] Bonus: Fixed TypeScript warning on `err.message` property.

### How to test

You can install either from source code or from GitHub.

#### Install from source

1. Switch to current branch.
2. Run `npm install`.
3. Open project in VSCode.
4. In the debugger be sure you have "Run Extension" mode selected.
5. Invoke "run" (<kbd>F5</kbd>).

#### Install from GitHub

1. Go to the latest release on the [release page](https://github.com/StyraInc/vscode-styra/releases).
2. Download the additional version piggybacked into that release, labelled `vscode-styra-n.n.n-next.N.vsix`.
3. Install via the standard command: `code --install-extension vscode-styra-n.n.n-next.N.vsix`

#### Exercise the Code

All internal; no discernible changes.

### Related Resources

STY-16149
