### PR TITLE
config-git: move away from deprecated arg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added VS Code setting `Diagnostic Limit` to limit length of diagnostic lines in output pane.
 - Added CONTRIBUTING.md to repository in preparation for going public.
 - Added issue templates for community members to more easily participate.
-- Removed restriction on commit formatting to make it less arduous for community members.
 - Additional info badges to top of extension's home page in VS Code (Slack, CI status, PR count)
+
+### Changed
+
+- Updated `Styra Link: Config Git` to no longer use deprecated argument
+- Removed restriction on commit formatting to make it less arduous for community members.
 
 ## [1.1.0] - 2023-04-06
 

--- a/src/commands/link-config-git.ts
+++ b/src/commands/link-config-git.ts
@@ -74,6 +74,7 @@ export class LinkConfigGit implements ICommand {
       'link',
       'config',
       'git',
+      '--repository',
       state.url,
       `--${state.syncStyleType.label}`,
       state.syncStyleValue,

--- a/src/test-jest/commands/link-config-git.test.ts
+++ b/src/test-jest/commands/link-config-git.test.ts
@@ -28,7 +28,7 @@ describe('LinkConfigGit', () => {
 
     expect(runnerMock).toHaveBeenCalledWith(
       'styra',
-      expect.arrayContaining(['link', 'config', 'git']),
+      expect.arrayContaining(['link', 'config', 'git', '--repository']),
       expect.anything()
     );
   });


### PR DESCRIPTION
### What code changed, and why?

```
 styra link config git 'git@github.com:StyraInc/expo-scan-repository.git'
```
needs to change to
```
 styra link config git --repository 'git@github.com:StyraInc/expo-scan-repository.git'
```

### Definition of done

When you run `Styra Link: Config Git` in VSCode, you no longer see the error indicated—this is the old invocation (notice the git URL is NOT preceded with `--repository`:
```
Spawning child process:
    project path: /Users/msorens/github/projects/_ms-demo-compliance-repo
    styra link config git 'git@github.com:StyraInc/expo-scan-repository.git' --branch master  --password-stdin --key-file '/Users/msorens/.ssh/id_rsa'
child process (styra) complete

ERROR: Warning: Use of the repository-url argument is deprecated and will be removed in a future version. Use the '--repository' flag instead.
```

### How to test

You can install either from source code or from GitHub.

#### Install from source

1. Switch to current branch.
2. Run `npm install`.
3. Open project in VSCode.
4. In the debugger be sure you have "Run Extension" mode selected.
5. Invoke "run" (<kbd>F5</kbd>).

#### Install from GitHub

1. Go to the latest release on the [release page](https://github.com/StyraInc/vscode-styra/releases).
2. Download the additional version piggybacked into that release, labelled `vscode-styra-n.n.n-next.N.vsix`.
3. Install via the standard command: `code --install-extension vscode-styra-n.n.n-next.N.vsix`

#### Exercise the Code

Run `Styra Link: Config Git`; the arguments do not matter much.

### Related Resources

STY-16083
