### PR TITLE
Prettify provenance output

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,6 +10,7 @@
     "typescript.tsc.autoDetect": "off",
     "cSpell.words": [
         "eopa",
+        "norc",
         "picomatch",
         "tsandall"
     ]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![slack](https://img.shields.io/badge/slack-styra-24b6e0.svg?logo=slack)](https://styracommunity.slack.com/)
 [![Apache License](https://img.shields.io/badge/license-Apache%202.0-orange.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 [![Visual Studio Marketplace Version](https://img.shields.io/visual-studio-marketplace/v/Styra.vscode-styra?color=24b6e0)](#)
-[![Coverage](https://img.shields.io/badge/Coverage-74%25-brightgreen)](#)
+[![Coverage](https://img.shields.io/badge/Coverage-73%25-brightgreen)](#)
 [![CI status](https://github.com/StyraInc/vscode-styra/actions/workflows/main.yaml/badge.svg)](https://github.com/StyraInc/vscode-styra/actions/workflows/main.yaml)
 [![closed PRs](https://img.shields.io/github/issues-pr-closed-raw/StyraInc/vscode-styra)](https://github.com/StyraInc/vscode-styra/pulls?q=is%3Apr+is%3Aclosed)
 <!--


### PR DESCRIPTION
### What code changed, and why?

Provenance data had a bug when initially putting pretty output together, but with that fixed the data can now be processed and output in a more human-readable format.

### Definition of done

When requesting previews with provenance data, the output is formatted for human consumption rather than dumped JSON.

### How to test

You can install this version from source code

#### Install from source

1. Switch to current branch.
2. Run `npm install`.
3. Open project in VSCode.
4. In the debugger be sure you have "Run Extension" mode selected.
5. Invoke "run" (<kbd>F5</kbd>).

#### Exercise the Code

Set up an EOPA environment with preview enabled that uses bundles. Run a preview request to that environment ensuring the 'provenance' argument is set to true. Check the output to see the human-readable output.

![Screenshot 2023-09-08 at 12 13 59 PM](https://github.com/StyraInc/vscode-styra/assets/1895738/9a7df66a-d287-4b4b-bbd4-3a16554bc6db)
