### PR TITLE
infrastructure: optimize package

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,9 +1,10 @@
-.vscode*/**
-.github/**
-coverage/**
-packaging/**
-src/**
-image/**
+.vscode
+.github
+coverage
+node_modules
+packaging
+src
+image
 **/*.map
 **/*.ts
 *.config.js
@@ -17,6 +18,7 @@ out/**
 *.md
 !README.md
 !CHANGELOG.md
+!SUPPORT.md
 
 *.json
 !package.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-styra",
-  "version": "2.0.1-next.0",
+  "version": "2.0.1-next.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-styra",
-      "version": "2.0.1-next.0",
+      "version": "2.0.1-next.1",
       "dependencies": {
         "command-exists": "^1.2.9",
         "fs-extra": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/StyraInc/vscode-styra/issues"
   },
   "publisher": "styra",
-  "version": "2.0.1-next.0",
+  "version": "2.0.1-next.1",
   "private": true,
   "main": "./out/main.js",
   "engines": {


### PR DESCRIPTION
### What code changed, and why?

Wondered why, when running `npm run package`, it complained
"For performance reasons, you should bundle your extension".
Puzzling because I _had_ been bundling already... 🤔 

PR bonus: Noticed the new SUPPORT.md exists, yet it was not included in the package, as is recommended at
https://code.visualstudio.com/api/working-with-extensions/publishing-extension#advanced-usage
I suspect this will automatically add a Support link on the extension's page within VSCode; will not be able to verify
until this becomes an official release in the VSCode marketplace.

### Definition of done

Bundle no longer includes node_modules but extension still works.

### How to test

1. Run `npm run package` from the base branch (msorens/include-vsce) to generate vscode-styra-2.0.1-next.0.vsix.
2. Switch to this branch.
3. Run `npm run package` to generate vscode-styra-2.0.1-next.1.vsix.

➡️ Observe the size differential: 963K vs 194k 🎉 

➡️ Observe the new bundle no longer includes node_modules. (A vsix file is just a zip file; rename it to .zip and use your standard tools to look into a zip file.)

➡️ Install the smaller package to confirm it works: `code --install-extension vscode-styra-2.0.1-next.1.vsix`
