### PR TITLE
styra-link: unhandled bad download URL for styra CLI causes cryptic error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- None
+### Fixed
+
+- Check that downloaded CLI binary is sane instead of assuming it is. With a bad download URL
+  this caused a cryptic "Error spawn Unknown system error -8" message.
 
 ## [2.0.0] - 2023-09-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Check that downloaded CLI binary is sane instead of assuming it is. With a bad download URL
-  this caused a cryptic "Error spawn Unknown system error -8" message.
+- Check that downloaded CLI binary is an actual binary (not a 404 page) instead of assuming it is.
+  With a bad download URL this caused a cryptic "Error spawn Unknown system error -8" message.
 
 ## [2.0.0] - 2023-09-25
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![slack](https://img.shields.io/badge/slack-styra-24b6e0.svg?logo=slack)](https://styracommunity.slack.com/)
 [![Apache License](https://img.shields.io/badge/license-Apache%202.0-orange.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 [![Visual Studio Marketplace Version](https://img.shields.io/visual-studio-marketplace/v/Styra.vscode-styra?color=24b6e0)](#)
-[![Coverage](https://img.shields.io/badge/Coverage-73%25-brightgreen)](#)
+[![Coverage](https://img.shields.io/badge/Coverage-72%25-brightgreen)](#)
 [![CI status](https://github.com/StyraInc/vscode-styra/actions/workflows/main.yaml/badge.svg)](https://github.com/StyraInc/vscode-styra/actions/workflows/main.yaml)
 [![closed PRs](https://img.shields.io/github/issues-pr-closed-raw/StyraInc/vscode-styra)](https://github.com/StyraInc/vscode-styra/pulls?q=is%3Apr+is%3Aclosed)
 <!--

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-styra",
-  "version": "2.0.1-next.1",
+  "version": "2.0.1-next.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-styra",
-      "version": "2.0.1-next.1",
+      "version": "2.0.1-next.2",
       "dependencies": {
         "command-exists": "^1.2.9",
         "fs-extra": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/StyraInc/vscode-styra/issues"
   },
   "publisher": "styra",
-  "version": "2.0.1-next.1",
+  "version": "2.0.1-next.2",
   "private": true,
   "main": "./out/main.js",
   "engines": {

--- a/src/commands/executor.ts
+++ b/src/commands/executor.ts
@@ -15,6 +15,7 @@ export class Executor {
     }
     if (!await StyraInstall.styraCmdExists()) {
       info(`"${STYRA_CLI_CMD}" not found; aborting ${command.title}`);
+      return;
     }
     // Deliberately delay the official start of a command until here;
     // that way, any diagnostic output from the above pre-flight steps are nicely separated.

--- a/src/lib/command-runner.ts
+++ b/src/lib/command-runner.ts
@@ -100,7 +100,6 @@ export class CommandRunner {
     const possibleError = options?.possibleError ?? '';
     const quiet = options?.quiet ?? false;
     if (!StyraInstall.checkWorkspace()) {
-      teeError('Something is wrong! Did you forget to run checkWorkspace in your command?');
       return '';
     }
     const projectDir = IDE.projectDir();

--- a/src/lib/styra-install.ts
+++ b/src/lib/styra-install.ts
@@ -147,8 +147,6 @@ export class StyraInstall {
   }
 
   private static async installStyra(): Promise<void> {
-    info(`    Platform: ${process.platform}`);
-    info(`    Architecture: ${process.arch}`);
 
     const tempFileLocation = path.join(os.homedir(), this.BinaryFile);
 
@@ -167,12 +165,10 @@ export class StyraInstall {
       cancellable: false
     }, async () => {
       await this.getBinary(url, tempFileLocation);
+      info(`    Platform: ${process.platform}`);
+      info(`    Architecture: ${process.arch}`);
       info(`    Executable: ${this.ExeFile}`);
       fs.chmodSync(tempFileLocation, '755');
-      if (fs.statSync(tempFileLocation).size < 1_000_000) { // crude but effective for a bad URL
-        fs.unlinkSync(tempFileLocation); // delete the file
-        throw new Error(`Probably bad URL for downloading styra - ${url}`);
-      }
       if (this.isWindows()) {
         await moveFile(tempFileLocation, this.ExeFile);
         await this.adjustWindowsPath(this.ExePath);
@@ -189,6 +185,12 @@ export class StyraInstall {
   private static async getBinary(url: string, tempFileLocation: string): Promise<void> {
     // adapted from https://stackoverflow.com/a/69290915
     const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(
+        response.status === 404 ? `Bad URL for downloading styra - ${url}`
+          : `Error attempting to downloading styra CLI: status = ${response.status}`);
+    }
+
     const writeStream = fse.createWriteStream(tempFileLocation, {
       autoClose: true,
       flags: 'w',

--- a/src/lib/styra-install.ts
+++ b/src/lib/styra-install.ts
@@ -169,6 +169,10 @@ export class StyraInstall {
       await this.getBinary(url, tempFileLocation);
       info(`    Executable: ${this.ExeFile}`);
       fs.chmodSync(tempFileLocation, '755');
+      if (fs.statSync(tempFileLocation).size < 1_000_000) { // crude but effective for a bad URL
+        fs.unlinkSync(tempFileLocation); // delete the file
+        throw new Error(`Probably bad URL for downloading styra - ${url}`);
+      }
       if (this.isWindows()) {
         await moveFile(tempFileLocation, this.ExeFile);
         await this.adjustWindowsPath(this.ExePath);

--- a/src/test-jest/commands/executor.test.ts
+++ b/src/test-jest/commands/executor.test.ts
@@ -25,8 +25,11 @@ describe('Executor', () => {
   const spy = new OutputPaneSpy();
   const spyAppendLine = jest.spyOn(outputChannel, 'appendLine');
   Executor.checkStartup = jest.fn();
-  StyraInstall.styraCmdExists = jest.fn().mockResolvedValue(true);
   IDE.getConfigValue = mockVSCodeSettings();
+
+  beforeEach(() => {
+    StyraInstall.styraCmdExists = jest.fn().mockResolvedValue(true);
+  });
 
   [
     [true, 'CONTINUES'],


### PR DESCRIPTION
### What code changed, and why?

With a bad URL the automatic install of the Styra CLI by the Styra VSCode plugin still resulted in storing _something_ at /usr/local/bin/styra, but not an executable binary(!). (Looks like a 404 page, essentially.) The code assumed that was the real thing, reported the CLI installation successful(!), tried to invoke it as the styra CLI, and said _"Error spawn Unknown system error -8"_, as shown:

<img width="683" alt="image" src="https://github.com/StyraInc/vscode-styra/assets/6817500/513da413-a439-4a99-af2c-bf60640f0b86">

This PR will now let the plugin recognize that the non-empty download was not an executable, so fails the "install" operation properly.

The solution here is not terribly elegant—just seeing if the download was larger than one megabyte—but it is a fast check.
I opted for fast rather than thorough because something like this would happen only rarely (like, um, well, now). 🤷 
Again, because it is rare, this handles the case of /usr/local/bin/styra being an imposter _at install time only_. The other case—which it does _not_ handle—is if you already have an imposter /usr/local/bin/styra when you try to run `Styra Link: Initialize...`

### Definition of done

With the current bad URLs for downloading the styra CLI, the system will now recognize the attempted install of /usr/local/bin/styra failed and abort at that point.

<img width="708" alt="image" src="https://github.com/StyraInc/vscode-styra/assets/6817500/1adea95c-17a5-40d5-bb00-c26a50dab694">

## 2024.04.16 update:
Using the HTTP response instead of my initial crude approach; also adjusted the output here slightly:
<img width="552" alt="image" src="https://github.com/StyraInc/vscode-styra/assets/6817500/f6b75945-ac31-4754-989d-6f3d988703b0">



### How to test

You can install either from source code or from GitHub.

#### Install from source

1. Switch to current branch.
2. Run `npm install`.
3. Open project in VSCode.
4. In the debugger be sure you have "Run Extension" mode selected.
5. Invoke "run" (<kbd>F5</kbd>).

#### Install from GitHub

1. Go to the latest release on the [release page](https://github.com/StyraInc/vscode-styra/releases).
2. Download the additional version piggybacked into that release, labelled `vscode-styra-2.0.1-next.2.vsix`.
3. Install via the standard command: `code --install-extension vscode-styra-2.0.1-next.2.vsix`

#### Exercise the Code

Make sure you do _not_ have `styra` on your search path, and in particular that you do _not_ have it in /usr/local/bin, since that is where the plugin installs to.

Attempt to run the VSCode palette command `Styra Link: Initialize...`.
Say "Yes" when asked if you want to install the Styra CLI.
Observe the Output pane.

