### PR TITLE
styra-link: correct Styra CLI download links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Check that downloaded CLI binary is an actual binary (not a 404 page) instead of assuming it is.
   With a bad download URL this caused a cryptic "Error spawn Unknown system error -8" message.
+- Fixed download URLs for auto-installing Styra CLI.
+- Optimized vsix package, making the plugin binary 80% smaller!
 
 ## [2.0.0] - 2023-09-25
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-styra",
-  "version": "2.0.1-next.2",
+  "version": "2.0.1-next.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-styra",
-      "version": "2.0.1-next.2",
+      "version": "2.0.1-next.3",
       "dependencies": {
         "command-exists": "^1.2.9",
         "fs-extra": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/StyraInc/vscode-styra/issues"
   },
   "publisher": "styra",
-  "version": "2.0.1-next.2",
+  "version": "2.0.1-next.3",
   "private": true,
   "main": "./out/main.js",
   "engines": {

--- a/src/lib/styra-install.ts
+++ b/src/lib/styra-install.ts
@@ -151,15 +151,16 @@ export class StyraInstall {
     //    https://nodejs.org/api/process.html#processarch
     //    https://nodejs.org/api/process.html#processplatform
     //    https://docs.styra.com/das/reference/cli (make sure stay in sync with this!)
+    const prefix = 'https://dl.styra.com/release/styra-cli/latest';
     return process.platform === 'win32'
-      ? 'https://dl.styra.com/release/styra-cli/latest/windows/amd64/styra.exe'
+      ? `${prefix}/windows/amd64/styra.exe`
       : process.platform === 'darwin'
         ? process.arch === 'arm64'
-          ? 'https://dl.styra.com/release/styra-cli/latest/darwin/arm64/styra'
-          : 'https://dl.styra.com/release/styra-cli/latest/darwin/amd64/styra' // otherwise target "x64"
+          ? `${prefix}/darwin/arm64/styra`
+          : `${prefix}/darwin/amd64/styra` // otherwise target "x64"
         : process.arch === 'arm64'
-          ? 'https://dl.styra.com/release/styra-cli/latest/linux/arm64/styra'
-          : 'https://dl.styra.com/release/styra-cli/latest/linux/amd64/styra';
+          ? `${prefix}/linux/arm64/styra`
+          : `${prefix}/linux/amd64/styra`;
   }
 
   private static async installStyra(): Promise<void> {

--- a/src/lib/styra-install.ts
+++ b/src/lib/styra-install.ts
@@ -146,18 +146,26 @@ export class StyraInstall {
     return styraPathInPath && styraExeExists;
   }
 
+  private static getDownloadUrl(): string {
+    // references:
+    //    https://nodejs.org/api/process.html#processarch
+    //    https://nodejs.org/api/process.html#processplatform
+    //    https://docs.styra.com/das/reference/cli (make sure stay in sync with this!)
+    return process.platform === 'win32'
+      ? 'https://dl.styra.com/release/styra-cli/latest/windows/amd64/styra.exe'
+      : process.platform === 'darwin'
+        ? process.arch === 'arm64'
+          ? 'https://dl.styra.com/release/styra-cli/latest/darwin/arm64/styra'
+          : 'https://dl.styra.com/release/styra-cli/latest/darwin/amd64/styra' // otherwise target "x64"
+        : process.arch === 'arm64'
+          ? 'https://dl.styra.com/release/styra-cli/latest/linux/arm64/styra'
+          : 'https://dl.styra.com/release/styra-cli/latest/linux/amd64/styra';
+  }
+
   private static async installStyra(): Promise<void> {
 
     const tempFileLocation = path.join(os.homedir(), this.BinaryFile);
-
-    const url =
-      process.platform === 'win32'
-        ? 'https://docs.styra.com/v1/docs/bin/windows/amd64/styra.exe'
-        : process.platform !== 'darwin'
-          ? 'https://docs.styra.com/v1/docs/bin/linux/amd64/styra'
-          : process.arch === 'arm64'
-            ? 'https://docs.styra.com/v1/docs/bin/darwin/arm64/styra'
-            : 'https://docs.styra.com/v1/docs/bin/darwin/amd64/styra'; // otherwise target "x64"
+    const url = this.getDownloadUrl();
 
     return await IDE.withProgress({
       location: IDE.ProgressLocation.Notification,


### PR DESCRIPTION
### What code changed, and why?

Styra CLI download links were outdated. Updated and added one new choice now available, too.

### Definition of done

Styra CLI can now be successfully installed by the Styra VSCode plugin.
<img width="726" alt="image" src="https://github.com/StyraInc/vscode-styra/assets/6817500/c92c0812-b377-41df-ac34-1b549e87d42c">


### How to test

You can install either from source code or from GitHub.

#### Install from source

1. Switch to current branch.
2. Run `npm install`.
3. Open project in VSCode.
4. In the debugger be sure you have "Run Extension" mode selected.
5. Invoke "run" (<kbd>F5</kbd>).

#### Install from GitHub

1. Go to the latest release on the [release page](https://github.com/StyraInc/vscode-styra/releases).
2. Download the additional version piggybacked into that release, labelled `vscode-styra-2.0.1-next.3.vsix`.
3. Install via the standard command: `code --install-extension vscode-styra-2.0.1-next.3.vsix`

#### Exercise the Code

Make sure you do _not_ have `styra` on your search path, and in particular that you do _not_ have it in /usr/local/bin, since that is where the plugin installs to.

Attempt to run the VSCode palette command `Styra Link: Initialize...`.
Say "Yes" when asked if you want to install the Styra CLI.
Observe the Output pane. The install should be successful.
Also, from your terminal (inside or outside VSCode) you should be able to run `styra version`
