### PR TITLE
styra-link: correct password flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   With a bad download URL this caused a cryptic "Error spawn Unknown system error -8" message.
 - Fixed download URLs for auto-installing Styra CLI.
 - Optimized vsix package, making the plugin binary 80% smaller!
+- Cancelling password entry during CLI install now aborts the progress bar, too.
+- Bad password during CLI install now reports a short, clean message instead of a cryptic, verbose one.
+- Password entry for CLI install now allows retries without re-downloading the CLI binary.
 
 ## [2.0.0] - 2023-09-25
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-styra",
-  "version": "2.0.1-next.3",
+  "version": "2.0.1-next.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-styra",
-      "version": "2.0.1-next.3",
+      "version": "2.0.1-next.4",
       "dependencies": {
         "command-exists": "^1.2.9",
         "fs-extra": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/StyraInc/vscode-styra/issues"
   },
   "publisher": "styra",
-  "version": "2.0.1-next.3",
+  "version": "2.0.1-next.4",
   "private": true,
   "main": "./out/main.js",
   "engines": {

--- a/src/test-jest/lib/styra-install.test.ts
+++ b/src/test-jest/lib/styra-install.test.ts
@@ -38,7 +38,7 @@ describe('StyraInstall', () => {
   }
 
   beforeEach(() => {
-    setPrivateMock('installStyra', jest.fn().mockResolvedValue(''));
+    setPrivateMock('downloadBinary', jest.fn().mockResolvedValue(''));
     setPrivateMock('installOnPath', jest.fn().mockResolvedValue(''));
     StyraInstall.styraCmdExists = jest.fn().mockResolvedValue(false);
     IDE.getConfigValue = mockVSCodeSettings();
@@ -95,9 +95,9 @@ describe('StyraInstall', () => {
       });
     });
 
-    test('returns true and succeeds if installStyra gets a bad pwd then a good pwd', async () => {
+    test('returns true and succeeds if get bad pwd then a good pwd', async () => {
       IDE.showInformationMessageModal = jest.fn().mockReturnValue('Install');
-      setPrivateMock('installStyra', jest.fn()
+      setPrivateMock('installOnPath', jest.fn()
         .mockRejectedValueOnce({message: 'Sorry, try again. Bad password'})
         .mockResolvedValueOnce(''));
 
@@ -106,9 +106,9 @@ describe('StyraInstall', () => {
       expect(spy.content).toMatch(/CLI installation completed/);
     });
 
-    test('returns false and fails if installStyra gets bad pwd, then some other error', async () => {
+    test('returns false and fails if get bad pwd, then some other error', async () => {
       IDE.showInformationMessageModal = jest.fn().mockReturnValue('Install');
-      setPrivateMock('installStyra', jest.fn()
+      setPrivateMock('installOnPath', jest.fn()
         .mockRejectedValueOnce({message: 'Sorry, try again. Bad password'})
         .mockRejectedValue({message: 'some error'}));
 
@@ -118,9 +118,9 @@ describe('StyraInstall', () => {
       expect(spy.content).toMatch(/some error/);
     });
 
-    test('returns false and fails if installStyra throws an error other than bad pwd', async () => {
+    test('returns false and fails if throws an error other than bad pwd', async () => {
       IDE.showInformationMessageModal = jest.fn().mockReturnValue('Install');
-      setPrivateMock('installStyra', jest.fn().mockRejectedValue({message: 'some error'}));
+      setPrivateMock('downloadBinary', jest.fn().mockRejectedValue({message: 'some error'}));
 
       expect(await StyraInstall.checkCliInstallation()).toBe(false);
       expect(spy.content).toMatch(/CLI installation failed/);


### PR DESCRIPTION
### What code changed, and why?

Several issues revolving around the password entry flow when installing the Styra CLI from the plugin.
DAS-770, DAS-771, DAS-772.

### Definition of done

OLD:
<img width="765" alt="image" src="https://github.com/StyraInc/vscode-styra/assets/6817500/8cd63c1c-4ddd-4795-b113-cef2f2335a8b">


NEW:
<img width="808" alt="image" src="https://github.com/StyraInc/vscode-styra/assets/6817500/3b9006c0-c354-4f58-9696-878a0ca09c8b">



1. fix poor error reporting upon bad password.

2. allow password retries without re-downloading full binary: Add loop for retry but move the binary fetch outside the loop 

3. cancel out of password entry closes progress bar.


### How to test

You can install either from source code or from GitHub.

#### Install from source

1. Switch to current branch.
2. Run `npm install`.
3. Open project in VSCode.
4. In the debugger be sure you have "Run Extension" mode selected.
5. Invoke "run" (<kbd>F5</kbd>).

#### Install from GitHub

1. Go to the latest release on the [release page](https://github.com/StyraInc/vscode-styra/releases).
2. Download the additional version piggybacked into that release, labelled `vscode-styra-2.0.1-next.4.vsix`.
3. Install via the standard command: `code --install-extension vscode-styra-2.0.1-next.4.vsix`

#### Exercise the Code

<!-- Fill in details here... -->

### Related Resources


